### PR TITLE
Online Suche von Dummy Ergebnissen auf funktionierende Suche umgestellt

### DIFF
--- a/Wikalyzer/Wikalyzer/App.axaml
+++ b/Wikalyzer/Wikalyzer/App.axaml
@@ -1,17 +1,26 @@
-<Application xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             x:Class="Wikalyzer.App"
-             xmlns:local="using:Wikalyzer"
-             RequestedThemeVariant="Light">
-             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+<Application
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Wikalyzer"
+    xmlns:converters="clr-namespace:Wikalyzer.Converters"
+    x:Class="Wikalyzer.App"
+    RequestedThemeVariant="Light">
+
 
     <Application.DataTemplates>
         <local:ViewLocator/>
     </Application.DataTemplates>
+    
+    <Application.Resources>
+        <!-- Konverter -->
+        <converters:NullToBooleanConverter x:Key="NullToBooleanConverter"/>
+        <converters:UrlToBitmapConverter   x:Key="UrlToBitmapConverter"/>
+    </Application.Resources>
 
-  
+
     <Application.Styles>
-        <FluentTheme />
-        <StyleInclude Source="avares://Wikalyzer/Assets/Icons.axaml"></StyleInclude>
+        <FluentTheme/>
+        <StyleInclude Source="avares://Wikalyzer/Assets/Icons.axaml"/>
     </Application.Styles>
+
 </Application>

--- a/Wikalyzer/Wikalyzer/Converters/NullToBooleanConverter.cs
+++ b/Wikalyzer/Wikalyzer/Converters/NullToBooleanConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace Wikalyzer.Converters
+{
+    /// <summary>
+    /// Konvertiert null/empty-Strings zu false, ansonsten true.
+    /// </summary>
+    public class NullToBooleanConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            // für string oder null generell
+            if (value is string s)
+                return !string.IsNullOrEmpty(s);
+            return value != null;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/Wikalyzer/Wikalyzer/Converters/UrlToBitmapConverter.cs
+++ b/Wikalyzer/Wikalyzer/Converters/UrlToBitmapConverter.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Globalization;
+using System.Net.Http;
+using Avalonia.Data.Converters;
+using Avalonia.Media.Imaging;
+
+namespace Wikalyzer.Converters;
+
+/// <summary>
+/// Lädt eine HTTP/HTTPS-URL herunter und liefert eine <see cref="Bitmap"/>
+/// für <c>Image.Source</c>.  Bei Fehlern → <c>null</c>.
+/// </summary>
+public class UrlToBitmapConverter : IValueConverter
+{
+    // global geteilter HttpClient
+    private static readonly HttpClient Http = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not string url || string.IsNullOrWhiteSpace(url))
+            return null;
+
+        try
+        {
+            // Download synchron (kleine Thumbnails → OK)
+            var stream = Http.GetStreamAsync(url)
+                .GetAwaiter()
+                .GetResult();
+
+            return new Bitmap(stream);
+        }
+        catch
+        {
+            // Bild konnte nicht geladen werden → kein Crash, kein Binding-Fehler
+            return null;
+        }
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/Wikalyzer/Wikalyzer/Models/ArticleSearchResult.cs
+++ b/Wikalyzer/Wikalyzer/Models/ArticleSearchResult.cs
@@ -1,0 +1,13 @@
+namespace Wikalyzer.Models
+{
+    /// <summary>
+    /// Ergebnis einer einzelnen Suchseite:
+    /// Titel, kurzer Extract und URL zum Thumbnail.
+    /// </summary>
+    public class ArticleSearchResult
+    {
+        public string  Title        { get; set; } = "";
+        public string  Summary      { get; set; } = "";
+        public string? ThumbnailUrl { get; set; }
+    }
+}

--- a/Wikalyzer/Wikalyzer/Models/NamespaceFilter.cs
+++ b/Wikalyzer/Wikalyzer/Models/NamespaceFilter.cs
@@ -1,0 +1,7 @@
+namespace Wikalyzer.Models;
+
+public class NamespaceFilter
+{
+    public string Name { get; set; } = "";
+    public int Id { get; set; }
+}

--- a/Wikalyzer/Wikalyzer/Services/WIkiLanguage.cs
+++ b/Wikalyzer/Wikalyzer/Services/WIkiLanguage.cs
@@ -1,0 +1,24 @@
+namespace Wikalyzer.Services
+{
+    /// <summary>
+    /// Unterstützte Wikipedia-Sprachen.
+    /// </summary>
+    public enum WikiLanguage
+    {
+        De,
+        En
+    }
+
+    public static class WikiLanguageExtensions
+    {
+        /// <summary>
+        /// Liefert den Sprachcode für die REST-API (z.B. "de", "en").
+        /// </summary>
+        public static string ToCode(this WikiLanguage lang) => lang switch
+        {
+            WikiLanguage.De => "de",
+            WikiLanguage.En => "en",
+            _               => "de"
+        };
+    }
+}

--- a/Wikalyzer/Wikalyzer/Services/WikiRestClient.cs
+++ b/Wikalyzer/Wikalyzer/Services/WikiRestClient.cs
@@ -1,0 +1,153 @@
+﻿// Services/WikiRestClient.cs
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Wikalyzer.Models;
+
+namespace Wikalyzer.Services;
+
+/// <summary>
+/// MediaWiki-Client auf Basis der Action-API  
+/// (action=query&amp;generator=search)  
+/// • liefert Extract + Thumbnail (pageimages) für Artikel  
+/// • liefert Original-Bild (imageinfo) für Dateiseiten  
+/// • bewahrt die API-Suchreihenfolge (Feld <c>index</c>)  
+/// </summary>
+public class WikiRestClient
+{
+    private readonly HttpClient _http;
+    private readonly string     _langCode;
+
+    public WikiRestClient(WikiLanguage lang)
+    {
+        _langCode = lang.ToCode();                // z.B. "de"
+        _http     = new HttpClient
+        {
+            BaseAddress = new Uri($"https://{_langCode}.wikipedia.org/")
+        };
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd("Wikalyzer/1.0");
+        _http.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+    }
+
+    /// <summary>
+    /// Führt eine Suche aus und gibt Artikel + Vorschaubilder zurück.
+    /// </summary>
+    public async Task<IEnumerable<ArticleSearchResult>> SearchWithThumbnailsAsync(
+        string term,
+        int    namespaceId = 0,
+        int    limit       = 10,
+        int    thumbSize   = 150)
+    {
+        // ───── 1) URL bauen ───────────────────────────────────────────
+        var sb = new System.Text.StringBuilder("w/api.php?action=query");
+        sb.Append("&format=json");
+        sb.Append("&generator=search");
+        sb.Append("&gsrsearch=").Append(Uri.EscapeDataString(term));
+        sb.Append("&gsrlimit=").Append(limit);
+        if (namespaceId >= 0)
+            sb.Append("&gsrnamespace=").Append(namespaceId);
+
+        // extracts + pageimages + imageinfo
+        sb.Append("&prop=extracts|pageimages|imageinfo");
+        sb.Append("&exintro=1&explaintext=1");
+        sb.Append("&piprop=thumbnail|original");
+        sb.Append("&pithumbsize=").Append(thumbSize);
+        sb.Append("&iiprop=url"); // Bild‐URL für Datei-Seiten
+
+        var url = sb.ToString();
+        Console.WriteLine($"[WikiRestClient] GET {_http.BaseAddress}{url}");
+
+        // ───── 2) HTTP-Anfrage ────────────────────────────────────────
+        HttpResponseMessage response;
+        try
+        {
+            response = await _http.GetAsync(url);
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.WriteLine($"[WikiRestClient] HTTP-Fehler: {ex.Message}");
+            return Array.Empty<ArticleSearchResult>();
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var err = await response.Content.ReadAsStringAsync();
+            Console.WriteLine($"[WikiRestClient] Status {(int)response.StatusCode}: {err}");
+            return Array.Empty<ArticleSearchResult>();
+        }
+
+        // ───── 3) JSON parsen ─────────────────────────────────────────
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var doc = await JsonDocument.ParseAsync(stream);
+
+        if (!doc.RootElement.TryGetProperty("query",  out var q) ||
+            !q.TryGetProperty("pages",                out var pages))
+            return Array.Empty<ArticleSearchResult>();
+
+        // nach Suchreihenfolge sortieren (Feld 'index')
+        var orderedPages = pages.EnumerateObject()
+                                .Select(p => p.Value)
+                                .Select(p => new
+                                {
+                                    Json  = p,
+                                    Index = p.TryGetProperty("index", out var idx)
+                                            ? idx.GetInt32()
+                                            : int.MaxValue
+                                })
+                                .OrderBy(x => x.Index)
+                                .Select(x => x.Json);
+
+        var results = new List<ArticleSearchResult>();
+
+        foreach (var p in orderedPages)
+        {
+            // Titel
+            var title = p.GetProperty("title").GetString() ?? "";
+
+            // Extract
+            var summary = p.TryGetProperty("extract", out var ex)
+                            ? ex.GetString() ?? ""
+                            : "";
+            summary = Regex.Replace(summary, "<.*?>", "");
+
+            // Bild-URL
+            string? thumb = null;
+
+            // pageimages-Thumbnail
+            if (p.TryGetProperty("thumbnail", out var tb) &&
+                tb.TryGetProperty("source", out var tbSrc))
+            {
+                thumb = tbSrc.GetString();
+            }
+            // imageinfo-Original (Datei-Namespace)
+            else if (p.TryGetProperty("imageinfo", out var ii) &&
+                     ii.ValueKind == JsonValueKind.Array &&
+                     ii[0].TryGetProperty("url", out var urlProp))
+            {
+                thumb = urlProp.GetString();
+            }
+            // letzter Fallback (Special:FilePath)
+            else if (namespaceId == 6)
+            {
+                var fileName = title.StartsWith("Datei:")
+                    ? title["Datei:".Length..]
+                    : title;
+                thumb = $"https://{_langCode}.wikipedia.org/wiki/Special:FilePath/{Uri.EscapeDataString(fileName)}";
+            }
+
+            results.Add(new ArticleSearchResult
+            {
+                Title        = title,
+                Summary      = summary,
+                ThumbnailUrl = thumb
+            });
+        }
+
+        Console.WriteLine($"[WikiRestClient] Parsed {results.Count} items.");
+        return results;
+    }
+}

--- a/Wikalyzer/Wikalyzer/Views/OnlineSearchView.axaml
+++ b/Wikalyzer/Wikalyzer/Views/OnlineSearchView.axaml
@@ -1,59 +1,89 @@
-<UserControl
-    xmlns="https://github.com/avaloniaui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:vm="using:Wikalyzer.ViewModels"
-    x:Class="Wikalyzer.Views.OnlineSearchView"
-    x:DataType="vm:OnlineSearchViewModel">
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Wikalyzer.ViewModels"
+             xmlns:models="clr-namespace:Wikalyzer.Models"
+             xmlns:converters="clr-namespace:Wikalyzer.Converters"
+             x:Class="Wikalyzer.Views.OnlineSearchView"
+             x:DataType="vm:OnlineSearchViewModel"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+  <Border Background="#1A2D3A" Padding="20">
+    <StackPanel Spacing="10">
+      <TextBlock Text="Online-Suche"
+                 FontSize="24" FontWeight="Bold"
+                 Foreground="White"
+                 HorizontalAlignment="Center"/>
 
-    <!-- Hintergrund -->
-    <Border Background="#1A2D3A" Padding="30">
+      <StackPanel Orientation="Horizontal" Spacing="8">
+        <ComboBox ItemsSource="{Binding Filters}"
+                  SelectedItem="{Binding SelectedFilter}"
+                  Width="120"
+                  Background="#263B50"
+                  Foreground="White"
+                  BorderBrush="#4FC3F7">
+          <ComboBox.ItemTemplate>
+            <DataTemplate DataType="models:NamespaceFilter">
+              <TextBlock Text="{Binding Name}" Foreground="White"/>
+            </DataTemplate>
+          </ComboBox.ItemTemplate>
+        </ComboBox>
 
-        <!-- Inhalt -->
-        <StackPanel Spacing="15">
-            
-            <!-- Titel -->
-            <TextBlock 
-                Text="Online-Suche"
-                FontSize="24"
-                FontWeight="Bold"
-                Foreground="White"
-                HorizontalAlignment="Center" />
+        <TextBox Width="250"
+                 Watermark="Begriff eingeben…"
+                 Text="{Binding SearchTerm, Mode=TwoWay}"
+                 Background="#263B50"
+                 Foreground="White"
+                 BorderBrush="#4FC3F7"/>
 
-            <!-- Suchfeld -->
-            <TextBox 
-                Watermark="Begriff eingeben..."
-                Text="{Binding SearchTerm, Mode=TwoWay}" 
-                Background="#263B50"
-                Foreground="White"
-                BorderBrush="#4FC3F7"
-                FontSize="14" />
-
-            <!-- Such-Button -->
-            <Button 
-                Content="Suchen"
-                Command="{Binding SearchCommand}" 
+        <Button Content="Suchen"
+                Command="{Binding SearchCommand}"
                 Background="#4FC3F7"
                 Foreground="Black"
-                FontWeight="Bold"
-                FontSize="14" />
+                Padding="10,5"/>
 
-            <!-- Ergebnisse -->
-            <ListBox 
-                ItemsSource="{Binding SearchResults}" 
-                Background="#263B50"
-                Foreground="White"
-                BorderBrush="Transparent"
-                Height="200" />
+        <ProgressBar Width="60"
+                     IsVisible="{Binding IsSearching}"
+                     IsIndeterminate="True"
+                     Height="4"
+                     VerticalAlignment="Bottom"
+                     Foreground="#4FC3F7"/>
+      </StackPanel>
 
-            <!-- Ladeanzeige -->
-            <TextBlock 
-                Text="🔍 Suche läuft..."
-                Foreground="#AAAAAA"
-                HorizontalAlignment="Center"
-                IsVisible="{Binding IsSearching}" />
-        </StackPanel>
-    </Border>
+      <ListBox ItemsSource="{Binding SearchResults}"
+               Background="#263B50"
+               BorderBrush="Transparent"
+               MaxHeight="400">
+        <ListBox.ItemTemplate>
+          <DataTemplate DataType="models:ArticleSearchResult">
+            <Border Background="#2E4050"
+                    CornerRadius="4"
+                    Padding="8"
+                    Margin="0,4,0,0">
+              <StackPanel Orientation="Horizontal" Spacing="10">
+                <Image Width="80" Height="80"
+                       Stretch="UniformToFill"
+                       Source="{Binding ThumbnailUrl,
+                        Converter={StaticResource UrlToBitmapConverter}}"
+                       IsVisible="{Binding ThumbnailUrl,
+                          Converter={StaticResource NullToBooleanConverter}}"/>
+
+                <StackPanel>
+                  <TextBlock Text="{Binding Title}"
+                             FontWeight="SemiBold"
+                             Foreground="White"
+                             FontSize="14"/>
+                  <TextBlock Text="{Binding Summary}"
+                             TextWrapping="Wrap"
+                             Foreground="#DDDDDD"
+                             FontSize="12"
+                             MaxWidth="600"/>
+                </StackPanel>
+              </StackPanel>
+            </Border>
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
+    </StackPanel>
+  </Border>
 </UserControl>
-
-
-


### PR DESCRIPTION
# Implementiere Online-Suche mit Wikipedia-API und Thumbnail-Anzeige

## Beschreibung
Dieser Pull Request fügt die komplette Online-Suchfunktion hinzu. Nutzer können nun über ein Dropdown den Namensraum (Artikel, Datei/Bild, Benutzer, Alle) wählen, einen Suchbegriff eingeben und per Button eine Abfrage an die Wikipedia REST-API senden. Die Ergebnisse werden in einer Liste mit Titel, Kurz-Beschreibung und Thumbnail (falls vorhanden) angezeigt. Während der Suche wird ein Ladeindikator eingeblendet.

## Änderungen

### ViewModel
- **`OnlineSearchViewModel`**  
  - Neue `Filters`-Liste (`NamespaceFilter`) für Namensräume.  
  - `SearchTerm`, `SelectedFilter`, `SearchResults`, `IsSearching` als ObservableProperties.  
  - `[RelayCommand] Search()` erzeugt `SearchCommand`, führt API-Call aus und füllt `SearchResults`.  
  - `CanSearch()` aktiviert Button nur, wenn `SearchTerm` nicht leer ist.  

### Service
- **`WikiRestClient.SearchWithThumbnailsAsync(...)`**  
  - Verwendet `action=query&generator=search` plus `pageimages|original` für Thumbnails.  
  - Parst JSON, extrahiert Titel, Kurztext und Thumbnail-URL.

### View
- **`OnlineSearchView.axaml`**  
  - ComboBox bindet an `Filters` / `SelectedFilter`.  
  - TextBox bindet an `SearchTerm`.  
  - Button bindet an `SearchCommand`, zeigt nur `Search` an, wenn `SearchTerm` gefüllt ist.  
  - ProgressBar (`IsVisible="{Binding IsSearching}"`) als Ladeindikator.  
  - ListBox mit DataTemplate für `ArticleSearchResult` (Image + Titel + Summary).  

### Converter & Ressourcen
- **`UrlToBitmapConverter`** für das Laden von Thumbnails aus HTTP-URLs.  
- **`NullToBooleanConverter`** blendet das Image nur ein, wenn `ThumbnailUrl != null`.  
- Farben, Abstände und CornerRadius an bestehendes Theme angepasst.

## Testing
1. **Namensraum „Artikel“ + Begriff „Berlin“** → Liste mit Einträgen und Geo-Thumbnails.  
2. **Namensraum „Datei/Bild“** → Liste mit Bilddateien, Vorschaubilder werden geladen.  
3. **Button-State** → „Suchen“ ist nur aktiv, wenn TextBox nicht leer.  
4. **ProgressBar** sichtbar, solange der API-Call läuft.
