### PR TITLE
Onlineanlyze erstellt

### DIFF
--- a/Wikalyzer/Wikalyzer/Converters/ZeroToBooleanConverter.cs
+++ b/Wikalyzer/Wikalyzer/Converters/ZeroToBooleanConverter.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace Wikalyzer.Converters;
+
+public class ZeroToBoolConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => (value is int count && count == 0);
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/Wikalyzer/Wikalyzer/Models/ArticleSearchResult.cs
+++ b/Wikalyzer/Wikalyzer/Models/ArticleSearchResult.cs
@@ -9,5 +9,6 @@ namespace Wikalyzer.Models
         public string  Title        { get; set; } = "";
         public string  Summary      { get; set; } = "";
         public string? ThumbnailUrl { get; set; }
+        public string PageUrl      { get; set; } = "";
     }
 }

--- a/Wikalyzer/Wikalyzer/Models/NamespaceFilter.cs
+++ b/Wikalyzer/Wikalyzer/Models/NamespaceFilter.cs
@@ -4,4 +4,6 @@ public class NamespaceFilter
 {
     public string Name { get; set; } = "";
     public int Id { get; set; }
+    public string Description { get; set; } = "";
+ 
 }

--- a/Wikalyzer/Wikalyzer/Models/TextStats.cs
+++ b/Wikalyzer/Wikalyzer/Models/TextStats.cs
@@ -7,8 +7,12 @@ public class TextStats
 {
     public int WordCount { get; set; }
     public int SentenceCount { get; set; }
-    public double AvgWordLength { get; set; }
-    public double AvgSentenceLength { get; set; }
-    public double WordDiversity { get; set; }
-    public Dictionary<string, int> TopWords { get; set; } = new();
+    public double AverageWordLength { get; set; }
+    public double AverageSentenceLength { get; set; }
+    public double LexicalDiversity { get; set; }  // Wortvielfalt in %
+    public string LongestSentence { get; set; } = "";
+    public string ShortestSentence { get; set; } = "";
+    public double ReadingTimeMinutes { get; set; }
+    public double FleschReadingEase { get; set; }
+    public List<string> TopWords { get; set; } = new();
 }

--- a/Wikalyzer/Wikalyzer/Services/TextAnalyzer.cs
+++ b/Wikalyzer/Wikalyzer/Services/TextAnalyzer.cs
@@ -1,6 +1,11 @@
 using System.Linq;
 using System.Text.RegularExpressions;
 using Wikalyzer.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Wikalyzer.Models;
 
 namespace Wikalyzer.Services;
 
@@ -8,21 +13,50 @@ public class TextAnalyzer
 {
     public TextStats Analyze(string text)
     {
-        var sentences = Regex.Split(text, "\r\n|\r|\n");
-        var words = Regex.Split(text.ToLower(), @"\W+").Where(w => w.Length > 0).ToArray();
-        var topWords = words.GroupBy(w => w)
-            . OrderByDescending(g => g.Count())
-            .Take(10)
-            .ToDictionary(g => g.Key, g => g.Count());
+        var stats = new TextStats();
 
-        return new TextStats()
-        {
-            WordCount = words.Length,
-            SentenceCount = sentences.Length,
-            AvgWordLength = words.Average(w => w.Length),
-            AvgSentenceLength = (double)words.Length / sentences.Length,
-            WordDiversity = (double)words.Distinct().Count() / words.Length,
-            TopWords = topWords
-        };
+        var sentences = Regex.Split(text, @"(?<=[.!?])\s+").Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+        var words = Regex.Matches(text, @"\b[\wäöüÄÖÜß]{2,}\b").Select(m => m.Value).ToList();
+
+        stats.WordCount = words.Count;
+        stats.SentenceCount = sentences.Count;
+        stats.AverageWordLength = words.Any() ? words.Average(w => w.Length) : 0;
+        stats.AverageSentenceLength = sentences.Any() ? words.Count / (double)sentences.Count : 0;
+
+        stats.LexicalDiversity = words.Distinct(StringComparer.OrdinalIgnoreCase).Count() / (double)(words.Count + 1) * 100;
+
+        stats.LongestSentence = sentences.OrderByDescending(s => s.Length).FirstOrDefault() ?? "";
+        stats.ShortestSentence = sentences.OrderBy(s => s.Length).FirstOrDefault() ?? "";
+
+        stats.ReadingTimeMinutes = Math.Round(words.Count / 200.0, 2); // 200 WpM
+
+        stats.FleschReadingEase = CalculateFleschEase(words, sentences);
+
+        stats.TopWords = words
+            .GroupBy(w => w.ToLowerInvariant())
+            .OrderByDescending(g => g.Count())
+            .ThenBy(g => g.Key)
+            .Take(10)
+            .Select(g => $"{g.Key} ({g.Count()})")
+            .ToList();
+
+        return stats;
+    }
+
+    private double CalculateFleschEase(List<string> words, List<string> sentences)
+    {
+        // Flesch-Wert für Deutsch: 180 - ASL - (58.5 * ASW)
+        // ASL = Durchschnittliche Satzlänge, ASW = Durchschnittliche Silbenanzahl pro Wort
+
+        double asl = sentences.Any() ? words.Count / (double)sentences.Count : 0;
+        double asw = words.Any() ? words.Average(w => CountSyllables(w)) : 0;
+
+        return Math.Round(180 - asl - (58.5 * asw), 2);
+    }
+
+    private int CountSyllables(string word)
+    {
+        // Grobe Heuristik für deutsche Silbenzählung:
+        return Regex.Matches(word.ToLower(), @"[aeiouyäöü]+").Count;
     }
 }

--- a/Wikalyzer/Wikalyzer/Services/WikiRestClient.cs
+++ b/Wikalyzer/Wikalyzer/Services/WikiRestClient.cs
@@ -2,152 +2,208 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Wikalyzer.Models;
 
-namespace Wikalyzer.Services;
-
-/// <summary>
-/// MediaWiki-Client auf Basis der Action-API  
-/// (action=query&amp;generator=search)  
-/// • liefert Extract + Thumbnail (pageimages) für Artikel  
-/// • liefert Original-Bild (imageinfo) für Dateiseiten  
-/// • bewahrt die API-Suchreihenfolge (Feld <c>index</c>)  
-/// </summary>
-public class WikiRestClient
+namespace Wikalyzer.Services
 {
-    private readonly HttpClient _http;
-    private readonly string     _langCode;
-
-    public WikiRestClient(WikiLanguage lang)
-    {
-        _langCode = lang.ToCode();                // z.B. "de"
-        _http     = new HttpClient
-        {
-            BaseAddress = new Uri($"https://{_langCode}.wikipedia.org/")
-        };
-        _http.DefaultRequestHeaders.UserAgent.ParseAdd("Wikalyzer/1.0");
-        _http.DefaultRequestHeaders.Accept.ParseAdd("application/json");
-    }
-
     /// <summary>
-    /// Führt eine Suche aus und gibt Artikel + Vorschaubilder zurück.
+    /// MediaWiki-Client auf Basis der Action-API  
+    /// (action=query&generator=search)  
+    /// • liefert Extract + Thumbnail (pageimages) für Artikel  
+    /// • liefert Original-Bild (imageinfo) für Dateiseiten  
+    /// • bewahrt die API-Suchreihenfolge (Feld <c>index</c>)  
+    /// Zusätzlich:
+    /// • GetArticleHtmlAsync holt den reinen HTML-Artikel  
+    /// • GetArticlePlainTextAsync wandelt HTML per Regex in formatierten Text um
     /// </summary>
-    public async Task<IEnumerable<ArticleSearchResult>> SearchWithThumbnailsAsync(
-        string term,
-        int    namespaceId = 0,
-        int    limit       = 10,
-        int    thumbSize   = 150)
+    public class WikiRestClient
     {
-        // ───── 1) URL bauen ───────────────────────────────────────────
-        var sb = new System.Text.StringBuilder("w/api.php?action=query");
-        sb.Append("&format=json");
-        sb.Append("&generator=search");
-        sb.Append("&gsrsearch=").Append(Uri.EscapeDataString(term));
-        sb.Append("&gsrlimit=").Append(limit);
-        if (namespaceId >= 0)
-            sb.Append("&gsrnamespace=").Append(namespaceId);
+        private readonly HttpClient _http;
+        private readonly string     _langCode;
 
-        // extracts + pageimages + imageinfo
-        sb.Append("&prop=extracts|pageimages|imageinfo");
-        sb.Append("&exintro=1&explaintext=1");
-        sb.Append("&piprop=thumbnail|original");
-        sb.Append("&pithumbsize=").Append(thumbSize);
-        sb.Append("&iiprop=url"); // Bild‐URL für Datei-Seiten
-
-        var url = sb.ToString();
-        Console.WriteLine($"[WikiRestClient] GET {_http.BaseAddress}{url}");
-
-        // ───── 2) HTTP-Anfrage ────────────────────────────────────────
-        HttpResponseMessage response;
-        try
+        public WikiRestClient(WikiLanguage lang)
         {
-            response = await _http.GetAsync(url);
-        }
-        catch (HttpRequestException ex)
-        {
-            Console.WriteLine($"[WikiRestClient] HTTP-Fehler: {ex.Message}");
-            return Array.Empty<ArticleSearchResult>();
-        }
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var err = await response.Content.ReadAsStringAsync();
-            Console.WriteLine($"[WikiRestClient] Status {(int)response.StatusCode}: {err}");
-            return Array.Empty<ArticleSearchResult>();
-        }
-
-        // ───── 3) JSON parsen ─────────────────────────────────────────
-        await using var stream = await response.Content.ReadAsStreamAsync();
-        using var doc = await JsonDocument.ParseAsync(stream);
-
-        if (!doc.RootElement.TryGetProperty("query",  out var q) ||
-            !q.TryGetProperty("pages",                out var pages))
-            return Array.Empty<ArticleSearchResult>();
-
-        // nach Suchreihenfolge sortieren (Feld 'index')
-        var orderedPages = pages.EnumerateObject()
-                                .Select(p => p.Value)
-                                .Select(p => new
-                                {
-                                    Json  = p,
-                                    Index = p.TryGetProperty("index", out var idx)
-                                            ? idx.GetInt32()
-                                            : int.MaxValue
-                                })
-                                .OrderBy(x => x.Index)
-                                .Select(x => x.Json);
-
-        var results = new List<ArticleSearchResult>();
-
-        foreach (var p in orderedPages)
-        {
-            // Titel
-            var title = p.GetProperty("title").GetString() ?? "";
-
-            // Extract
-            var summary = p.TryGetProperty("extract", out var ex)
-                            ? ex.GetString() ?? ""
-                            : "";
-            summary = Regex.Replace(summary, "<.*?>", "");
-
-            // Bild-URL
-            string? thumb = null;
-
-            // pageimages-Thumbnail
-            if (p.TryGetProperty("thumbnail", out var tb) &&
-                tb.TryGetProperty("source", out var tbSrc))
+            _langCode = lang.ToCode(); // z.B. "de"
+            _http     = new HttpClient
             {
-                thumb = tbSrc.GetString();
+                BaseAddress = new Uri($"https://{_langCode}.wikipedia.org/")
+            };
+            _http.DefaultRequestHeaders.UserAgent.ParseAdd("Wikalyzer/1.0");
+            _http.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+        }
+
+        /// <summary>
+        /// Führt eine Suche aus und gibt Artikel + Vorschaubilder zurück.
+        /// </summary>
+        public async Task<IEnumerable<ArticleSearchResult>> SearchWithThumbnailsAsync(
+            string term,
+            int    namespaceId = 0,
+            int    limit       = 10,
+            int    thumbSize   = 150)
+        {
+            var sb = new StringBuilder("w/api.php?action=query");
+            sb.Append("&format=json")
+              .Append("&generator=search")
+              .Append("&gsrsearch=").Append(Uri.EscapeDataString(term))
+              .Append("&gsrlimit=").Append(limit);
+            if (namespaceId >= 0)
+                sb.Append("&gsrnamespace=").Append(namespaceId);
+
+            sb.Append("&prop=extracts|pageimages|imageinfo")
+              .Append("&exintro=1&explaintext=1")
+              .Append("&piprop=thumbnail|original")
+              .Append("&pithumbsize=").Append(thumbSize)
+              .Append("&iiprop=url");
+
+            var url = sb.ToString();
+            Console.WriteLine($"[WikiRestClient] GET {_http.BaseAddress}{url}");
+
+            HttpResponseMessage response;
+            try
+            {
+                response = await _http.GetAsync(url);
             }
-            // imageinfo-Original (Datei-Namespace)
-            else if (p.TryGetProperty("imageinfo", out var ii) &&
-                     ii.ValueKind == JsonValueKind.Array &&
-                     ii[0].TryGetProperty("url", out var urlProp))
+            catch (HttpRequestException ex)
             {
-                thumb = urlProp.GetString();
-            }
-            // letzter Fallback (Special:FilePath)
-            else if (namespaceId == 6)
-            {
-                var fileName = title.StartsWith("Datei:")
-                    ? title["Datei:".Length..]
-                    : title;
-                thumb = $"https://{_langCode}.wikipedia.org/wiki/Special:FilePath/{Uri.EscapeDataString(fileName)}";
+                Console.WriteLine($"[WikiRestClient] HTTP-Fehler: {ex.Message}");
+                return Array.Empty<ArticleSearchResult>();
             }
 
-            results.Add(new ArticleSearchResult
+            if (!response.IsSuccessStatusCode)
             {
-                Title        = title,
-                Summary      = summary,
-                ThumbnailUrl = thumb
-            });
+                var err = await response.Content.ReadAsStringAsync();
+                Console.WriteLine($"[WikiRestClient] Status {(int)response.StatusCode}: {err}");
+                return Array.Empty<ArticleSearchResult>();
+            }
+
+            await using var stream = await response.Content.ReadAsStreamAsync();
+            using var doc = await JsonDocument.ParseAsync(stream);
+
+            if (!doc.RootElement.TryGetProperty("query",  out var q) ||
+                !q.TryGetProperty("pages",                out var pages))
+                return Array.Empty<ArticleSearchResult>();
+
+            var orderedPages = pages.EnumerateObject()
+                                    .Select(p => p.Value)
+                                    .Select(p => new
+                                    {
+                                        Json  = p,
+                                        Index = p.TryGetProperty("index", out var idx)
+                                                ? idx.GetInt32()
+                                                : int.MaxValue
+                                    })
+                                    .OrderBy(x => x.Index)
+                                    .Select(x => x.Json);
+
+            var results = new List<ArticleSearchResult>();
+
+            foreach (var p in orderedPages)
+            {
+                var title   = p.GetProperty("title").GetString() ?? "";
+                var summary = p.TryGetProperty("extract", out var ex)
+                                  ? ex.GetString() ?? ""
+                                  : "";
+                summary = Regex.Replace(summary, "<.*?>", "");
+
+                string? thumb = null;
+                if (p.TryGetProperty("thumbnail", out var tb) &&
+                    tb.TryGetProperty("source", out var tbSrc))
+                {
+                    thumb = tbSrc.GetString();
+                }
+                else if (p.TryGetProperty("imageinfo", out var ii) &&
+                         ii.ValueKind == JsonValueKind.Array &&
+                         ii[0].TryGetProperty("url", out var urlProp))
+                {
+                    thumb = urlProp.GetString();
+                }
+                else if (namespaceId == 6)
+                {
+                    var fileName = title.StartsWith("Datei:")
+                        ? title["Datei:".Length..]
+                        : title;
+                    thumb = $"https://{_langCode}.wikipedia.org/wiki/Special:FilePath/{Uri.EscapeDataString(fileName)}";
+                }
+
+                results.Add(new ArticleSearchResult
+                {
+                    Title        = title,
+                    Summary      = summary,
+                    ThumbnailUrl = thumb
+                });
+            }
+
+            Console.WriteLine($"[WikiRestClient] Parsed {results.Count} items.");
+            return results;
         }
 
-        Console.WriteLine($"[WikiRestClient] Parsed {results.Count} items.");
-        return results;
+        /// <summary>
+        /// Holt den reinen HTML-Artikel über die REST-API.
+        /// </summary>
+        public async Task<string> GetArticleHtmlAsync(string title)
+        {
+            var restUrl = $"api/rest_v1/page/html/{Uri.EscapeDataString(title)}";
+            HttpResponseMessage resp;
+            try
+            {
+                resp = await _http.GetAsync(restUrl);
+            }
+            catch
+            {
+                return string.Empty;
+            }
+
+            if (!resp.IsSuccessStatusCode)
+                return string.Empty;
+
+            return await resp.Content.ReadAsStringAsync();
+        }
+
+        /// <summary>
+        /// Wandelt den HTML-Artikel per Regex in formatierten Plain‑Text um
+        /// (Überschriften in Großbuchstaben, Absätze mit Leerzeilen).
+        /// </summary>
+        public async Task<string> GetArticlePlainTextAsync(string title)
+        {
+            var html = await GetArticleHtmlAsync(title);
+            if (string.IsNullOrWhiteSpace(html))
+                return "(Artikel konnte nicht geladen werden)";
+
+            // Regex für <h1>, <h2> und <p>
+            var pattern = @"<(h[12])\b[^>]*>(.*?)</\1>|<p\b[^>]*>(.*?)</p>";
+            var regex   = new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            var sb      = new StringBuilder();
+
+            foreach (Match m in regex.Matches(html))
+            {
+                // Überschrift-Gruppe
+                if (m.Groups[2].Success)
+                {
+                    var heading = WebUtility.HtmlDecode(m.Groups[2].Value.Trim());
+                    if (string.IsNullOrEmpty(heading)) continue;
+
+                    sb.AppendLine();
+                    sb.AppendLine(heading.ToUpperInvariant());
+                    sb.AppendLine(new string('-', heading.Length));
+                }
+                // Absatz-Gruppe
+                else if (m.Groups[3].Success)
+                {
+                    var para = WebUtility.HtmlDecode(m.Groups[3].Value.Trim());
+                    if (string.IsNullOrEmpty(para)) continue;
+
+                    sb.AppendLine(para);
+                    sb.AppendLine();
+                }
+            }
+
+            return sb.ToString().Trim();
+        }
     }
 }

--- a/Wikalyzer/Wikalyzer/ViewModels/ArticleViewModel.cs
+++ b/Wikalyzer/Wikalyzer/ViewModels/ArticleViewModel.cs
@@ -1,0 +1,54 @@
+﻿// ViewModels/ArticleViewModel.cs
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Wikalyzer.Models;
+using Wikalyzer.Services;
+
+namespace Wikalyzer.ViewModels;
+
+public partial class ArticleViewModel : ViewModelBase
+{
+    private readonly WikiRestClient _wiki = new(WikiLanguage.De);
+    private readonly TextAnalyzer   _analyzer = new();
+
+    public string Title { get; }
+    public string ArticleUrl { get; }
+    public string Summary { get; }
+
+    [ObservableProperty]
+    private string _articleText = string.Empty;      // Hier landet der formatierte Text
+
+    [ObservableProperty]
+    private TextStats _stats = new();                // Analyse-Ergebnisse
+
+    [ObservableProperty]
+    private bool _isSidebarOpen;                     // Sidebar-Visibility
+
+    public ArticleViewModel(string title, string articleUrl, string summary)
+    {
+        Title      = title;
+        ArticleUrl = articleUrl;
+        Summary    = summary;
+    }
+
+    /// <summary>
+    /// Lädt den Artikel-Text per Regex-Parsen und füllt <see cref="ArticleText"/>.
+    /// Generiert: <c>LoadArticleTextCommand</c>.
+    /// </summary>
+    [RelayCommand]
+    private async Task LoadArticleTextAsync()
+    {
+        ArticleText = await _wiki.GetArticlePlainTextAsync(Title);
+    }
+
+    /// <summary>
+    /// Analysiert den aktuell geladenen <see cref="ArticleText"/>.
+    /// Generiert: <c>AnalyzeCommand</c>.
+    /// </summary>
+    [RelayCommand]
+    private void Analyze()
+    {
+        Stats = _analyzer.Analyze(ArticleText);
+    }
+}

--- a/Wikalyzer/Wikalyzer/ViewModels/ArticleViewModel.cs
+++ b/Wikalyzer/Wikalyzer/ViewModels/ArticleViewModel.cs
@@ -3,7 +3,13 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Wikalyzer.Models;
+using System.Collections.Generic;
+using Avalonia.Media;
+using System.Text.RegularExpressions;
 using Wikalyzer.Services;
+using Avalonia.Controls;
+using Markdig;
+using Avalonia;
 
 namespace Wikalyzer.ViewModels;
 
@@ -25,6 +31,8 @@ public partial class ArticleViewModel : ViewModelBase
     [ObservableProperty]
     private bool _isSidebarOpen;                     // Sidebar-Visibility
 
+    [ObservableProperty] private List<object> _renderedBlocks = new();
+
     public ArticleViewModel(string title, string articleUrl, string summary)
     {
         Title      = title;
@@ -36,11 +44,93 @@ public partial class ArticleViewModel : ViewModelBase
     /// Lädt den Artikel-Text per Regex-Parsen und füllt <see cref="ArticleText"/>.
     /// Generiert: <c>LoadArticleTextCommand</c>.
     /// </summary>
+    [ObservableProperty]
+    private string _articleHtml = string.Empty; // Für WebView
+
+
     [RelayCommand]
     private async Task LoadArticleTextAsync()
     {
-        ArticleText = await _wiki.GetArticlePlainTextAsync(Title);
+        var raw = await _wiki.GetArticleMarkdownAsync(Title);
+        ArticleText = raw;
+        RenderMarkdownBlocks(raw);
     }
+    private void RenderMarkdownBlocks(string markdown)
+    {
+        var blocks = new List<object>();
+        var lines = markdown.Split('\n');
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                blocks.Add(new TextBlock { Text = "", Margin = new Thickness(0, 4) });
+                continue;
+            }
+
+            // === Markdown-Überschriften ===
+            if (line.StartsWith("### "))
+            {
+                blocks.Add(new TextBlock
+                {
+                    Text = line[4..].Trim(),
+                    FontWeight = FontWeight.Bold,
+                    FontSize = 18,
+                    Foreground = Brushes.White,
+                    Margin = new Thickness(0, 12, 0, 6)
+                });
+                continue;
+            }
+            if (line.StartsWith("## "))
+            {
+                blocks.Add(new TextBlock
+                {
+                    Text = line[3..].Trim(),
+                    FontWeight = FontWeight.Bold,
+                    FontSize = 22,
+                    Foreground = Brushes.White,
+                    Margin = new Thickness(0, 20, 0, 8)
+                });
+                continue;
+            }
+
+            // === Bulletpoints ===
+            if (line.StartsWith("- "))
+            {
+                blocks.Add(new TextBlock
+                {
+                    Text = "• " + StripMarkdown(line[2..]),
+                    Foreground = Brushes.White,
+                    Margin = new Thickness(0, 2)
+                });
+                continue;
+            }
+
+            // === Absatz (normaler Text) ===
+            blocks.Add(new TextBlock
+            {
+                Text = StripMarkdown(line),
+                Foreground = Brushes.White,
+                TextWrapping = TextWrapping.Wrap,
+                FontSize = 14,
+                Margin = new Thickness(0, 2)
+            });
+        }
+
+        RenderedBlocks = blocks;
+    }
+
+
+    private static string StripMarkdown(string text)
+    {
+        text = Regex.Replace(text, @"\*\*(.*?)\*\*", "$1");
+        text = Regex.Replace(text, @"_(.*?)_", "$1");
+        text = Regex.Replace(text, @"\[(.*?)\]\((.*?)\)", "$1");
+        return text;
+    }
+
 
     /// <summary>
     /// Analysiert den aktuell geladenen <see cref="ArticleText"/>.
@@ -51,4 +141,6 @@ public partial class ArticleViewModel : ViewModelBase
     {
         Stats = _analyzer.Analyze(ArticleText);
     }
+
+
 }

--- a/Wikalyzer/Wikalyzer/ViewModels/OnlineSearchViewModel.cs
+++ b/Wikalyzer/Wikalyzer/ViewModels/OnlineSearchViewModel.cs
@@ -18,12 +18,14 @@ public partial class OnlineSearchViewModel : ViewModelBase
         _wiki = new WikiRestClient(WikiLanguage.De);
         Filters = new ObservableCollection<NamespaceFilter>
         {
-            new() { Name="Artikel",    Id=0 },
-            new() { Name="Benutzer",   Id=2 },
-            new() { Name="Datei/Bild", Id=6 },
-            new() { Name="Alle",       Id=-1 }
+            new() { Name = "Artikel",    Id = 0,  Description = "Nur Wikipedia-Artikel durchsuchen" },
+            new() { Name = "Benutzer",   Id = 2,  Description = "Benutzerseiten auf Wikipedia durchsuchen" },
+            new() { Name = "Datei/Bild", Id = 6,  Description = "Dateien und Bilder aus Wikimedia Commons durchsuchen" },
+            new() { Name = "Alle",       Id = -1, Description = "Alle verfügbaren Namensräume einbeziehen" }
         };
+
         SelectedFilter = Filters.First();
+        
     }
 
     [ObservableProperty] private string? _searchTerm;
@@ -48,4 +50,5 @@ public partial class OnlineSearchViewModel : ViewModelBase
 
         IsSearching = false;
     }
+    
 }

--- a/Wikalyzer/Wikalyzer/Views/ArticleViewWindow.axaml
+++ b/Wikalyzer/Wikalyzer/Views/ArticleViewWindow.axaml
@@ -12,42 +12,139 @@
             <ColumnDefinition Width="2*"/>
         </Grid.ColumnDefinitions>
 
-        <!-- → formatierter Artikeltext mit Border für Padding -->
-        <Border Grid.Column="0" Padding="20">
+        <!-- Linke Seite: gerenderter Artikel -->
+        <Border Grid.Column="0" Padding="20" Background="#1A2D3A">
             <ScrollViewer>
-                <TextBlock Text="{Binding ArticleText}"
-                           FontFamily="Segoe UI"
-                           FontSize="14"
-                           TextWrapping="Wrap"/>
+                <ItemsControl ItemsSource="{Binding RenderedBlocks}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <ContentPresenter Content="{Binding}" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
             </ScrollViewer>
         </Border>
 
-        <!-- → Sidebar mit Border für Background und Padding -->
-        <Border Grid.Column="1"
-                Background="#2C3E50"
-                Padding="10">
-            <DockPanel>
-                <StackPanel Spacing="12">
-                    <Button Content="Artikel laden"
-                            Command="{Binding LoadArticleTextCommand}"
-                            Background="#4FC3F7"
-                            Foreground="Black"
-                            Padding="10,5"/>
-                    <TextBlock Text="Statistik"
-                               Foreground="White"
-                               FontWeight="Bold"
-                               Margin="0,20,0,0"/>
-                    <TextBlock Text="{Binding Stats.WordCount, StringFormat='Wörter: {0}'}"
-                               Foreground="White"/>
-                    <TextBlock Text="{Binding Stats.SentenceCount, StringFormat='Sätze: {0}'}"
-                               Foreground="White"/>
-                    <Button Content="Analyse starten"
-                            Command="{Binding AnalyzeCommand}"
-                            Background="#4FC3F7"
-                            Foreground="Black"
-                            Padding="10,5"/>
-                </StackPanel>
-            </DockPanel>
-        </Border>
+<!-- Rechte Seite: Sidebar -->
+<Border Grid.Column="1" Background="#2C3E50" Padding="10">
+    <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Spacing="12">
+            <Button Content="Artikel laden"
+                    Command="{Binding LoadArticleTextCommand}"
+                    Background="#4FC3F7"
+                    Foreground="Black"
+                    Padding="10,5"/>
+
+            <TextBlock Text="Statistik"
+                       Foreground="White"
+                       FontWeight="Bold"
+                       Margin="0,20,0,0"/>
+
+            <!-- Wörter -->
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <TextBlock Text="{Binding Stats.WordCount, StringFormat=Wörter: {0}}" Foreground="White"/>
+                <TextBlock Text="ᐩ" FontSize="14" Foreground="#4FC3F7">
+                    <ToolTip.Tip>
+                        <ToolTip>
+                            <TextBlock Text="Anzahl aller Wörter im Artikeltext"/>
+                        </ToolTip>
+                    </ToolTip.Tip>
+                </TextBlock>
+            </StackPanel>
+
+            <!-- Sätze -->
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <TextBlock Text="{Binding Stats.SentenceCount, StringFormat=Sätze: {0}}" Foreground="White"/>
+                <TextBlock Text="ᐩ" FontSize="14" Foreground="#4FC3F7">
+                    <ToolTip.Tip>
+                        <ToolTip>
+                            <TextBlock Text="Anzahl erkannter Sätze anhand von ., ! oder ?"/>
+                        </ToolTip>
+                    </ToolTip.Tip>
+                </TextBlock>
+            </StackPanel>
+
+            <!-- Ø Wortlänge -->
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <TextBlock Text="{Binding Stats.AverageWordLength, StringFormat=Ø Wortlänge: {0:F2}}" Foreground="White"/>
+                <TextBlock Text="ᐩ" FontSize="14" Foreground="#4FC3F7">
+                    <ToolTip.Tip>
+                        <ToolTip>
+                            <TextBlock Text="Durchschnittliche Länge aller Wörter in Zeichen"/>
+                        </ToolTip>
+                    </ToolTip.Tip>
+                </TextBlock>
+            </StackPanel>
+
+            <!-- Ø Satzlänge -->
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <TextBlock Text="{Binding Stats.AverageSentenceLength, StringFormat=Ø Satzlänge: {0:F2}}" Foreground="White"/>
+                <TextBlock Text="ᐩ" FontSize="14" Foreground="#4FC3F7">
+                    <ToolTip.Tip>
+                        <ToolTip>
+                            <TextBlock Text="Durchschnittliche Wortanzahl pro Satz"/>
+                        </ToolTip>
+                    </ToolTip.Tip>
+                </TextBlock>
+            </StackPanel>
+
+            <!-- Wortvielfalt -->
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <TextBlock Text="{Binding Stats.LexicalDiversity, StringFormat=Wortvielfalt: {0:P1}}" Foreground="White"/>
+                <TextBlock Text="ᐩ" FontSize="14" Foreground="#4FC3F7">
+                    <ToolTip.Tip>
+                        <ToolTip>
+                            <TextBlock Text="Anteil eindeutiger Wörter am Gesamtwortvorrat"/>
+                        </ToolTip>
+                    </ToolTip.Tip>
+                </TextBlock>
+            </StackPanel>
+
+            <!-- Lesedauer -->
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <TextBlock Text="{Binding Stats.ReadingTimeMinutes, StringFormat=Lesedauer: {0:F2} min}" Foreground="White"/>
+                <TextBlock Text="ᐩ" FontSize="14" Foreground="#4FC3F7">
+                    <ToolTip.Tip>
+                        <ToolTip>
+                            <TextBlock Text="Geschätzte Lesezeit bei 200 Wörtern pro Minute"/>
+                        </ToolTip>
+                    </ToolTip.Tip>
+                </TextBlock>
+            </StackPanel>
+
+            <!-- Flesch-Wert -->
+            <StackPanel Orientation="Horizontal" Spacing="4">
+                <TextBlock Text="{Binding Stats.FleschReadingEase, StringFormat=Flesch-Wert: {0:F1}}" Foreground="White"/>
+                <TextBlock Text="ᐩ" FontSize="14" Foreground="#4FC3F7">
+                    <ToolTip.Tip>
+                        <ToolTip>
+                            <TextBlock Text="Lesbarkeitsindex: höher = leichter zu lesen (Deutsch: bis 100)"/>
+                        </ToolTip>
+                    </ToolTip.Tip>
+                </TextBlock>
+            </StackPanel>
+
+            <!-- Längster Satz -->
+            <TextBlock Text="Längster Satz:" FontWeight="Bold" Margin="0,10,0,0" Foreground="White"/>
+            <TextBlock Text="{Binding Stats.LongestSentence}" TextWrapping="Wrap" Foreground="#DDDDDD"/>
+            <!-- Top-Wörter -->
+            <TextBlock Text="Top-Wörter:" FontWeight="Bold" Margin="0,10,0,0" Foreground="White"/>
+            <ItemsControl ItemsSource="{Binding Stats.TopWords}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding}" Foreground="#DDDDDD"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Button Content="Analyse starten"
+                    Command="{Binding AnalyzeCommand}"
+                    Background="#4FC3F7"
+                    Foreground="Black"
+                    Padding="10,5"
+                    Margin="0,20,0,0"/>
+        </StackPanel>
+    </ScrollViewer>
+</Border>
+
     </Grid>
 </Window>

--- a/Wikalyzer/Wikalyzer/Views/ArticleViewWindow.axaml
+++ b/Wikalyzer/Wikalyzer/Views/ArticleViewWindow.axaml
@@ -1,0 +1,53 @@
+﻿<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:Wikalyzer.ViewModels"
+        x:Class="Wikalyzer.Views.ArticleViewWindow"
+        x:DataType="vm:ArticleViewModel"
+        Width="1000" Height="700"
+        Title="{Binding Title}">
+
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="3*"/>
+            <ColumnDefinition Width="2*"/>
+        </Grid.ColumnDefinitions>
+
+        <!-- → formatierter Artikeltext mit Border für Padding -->
+        <Border Grid.Column="0" Padding="20">
+            <ScrollViewer>
+                <TextBlock Text="{Binding ArticleText}"
+                           FontFamily="Segoe UI"
+                           FontSize="14"
+                           TextWrapping="Wrap"/>
+            </ScrollViewer>
+        </Border>
+
+        <!-- → Sidebar mit Border für Background und Padding -->
+        <Border Grid.Column="1"
+                Background="#2C3E50"
+                Padding="10">
+            <DockPanel>
+                <StackPanel Spacing="12">
+                    <Button Content="Artikel laden"
+                            Command="{Binding LoadArticleTextCommand}"
+                            Background="#4FC3F7"
+                            Foreground="Black"
+                            Padding="10,5"/>
+                    <TextBlock Text="Statistik"
+                               Foreground="White"
+                               FontWeight="Bold"
+                               Margin="0,20,0,0"/>
+                    <TextBlock Text="{Binding Stats.WordCount, StringFormat='Wörter: {0}'}"
+                               Foreground="White"/>
+                    <TextBlock Text="{Binding Stats.SentenceCount, StringFormat='Sätze: {0}'}"
+                               Foreground="White"/>
+                    <Button Content="Analyse starten"
+                            Command="{Binding AnalyzeCommand}"
+                            Background="#4FC3F7"
+                            Foreground="Black"
+                            Padding="10,5"/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
+    </Grid>
+</Window>

--- a/Wikalyzer/Wikalyzer/Views/ArticleViewWindow.axaml.cs
+++ b/Wikalyzer/Wikalyzer/Views/ArticleViewWindow.axaml.cs
@@ -1,0 +1,15 @@
+﻿// Views/ArticleViewWindow.axaml.cs
+using Avalonia.Controls;
+using Wikalyzer.ViewModels;
+
+
+namespace Wikalyzer.Views;
+
+public partial class ArticleViewWindow : Window
+{
+    public ArticleViewWindow(string title, string url, string summary)
+    {
+        InitializeComponent();
+        DataContext = new ArticleViewModel(title, url, summary);
+    }
+} 

--- a/Wikalyzer/Wikalyzer/Views/ArticleViewWindow.axaml.cs
+++ b/Wikalyzer/Wikalyzer/Views/ArticleViewWindow.axaml.cs
@@ -1,15 +1,26 @@
 ﻿// Views/ArticleViewWindow.axaml.cs
 using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
 using Wikalyzer.ViewModels;
 
-
-namespace Wikalyzer.Views;
-
-public partial class ArticleViewWindow : Window
+namespace Wikalyzer.Views
 {
-    public ArticleViewWindow(string title, string url, string summary)
+    public partial class ArticleViewWindow : Window
     {
-        InitializeComponent();
-        DataContext = new ArticleViewModel(title, url, summary);
+        // 1) Parameterloser Konstruktor für XAML-Instanziierung
+        public ArticleViewWindow()
+        {
+            InitializeComponent();
+        }
+
+        // 2) Zusätzlicher Convenience-Konstruktor, der direkt den VM setzt
+        public ArticleViewWindow(string title, string articleUrl, string summary)
+            : this()
+        {
+            DataContext = new ArticleViewModel(title, articleUrl, summary);
+        }
+
+        private void InitializeComponent()
+            => AvaloniaXamlLoader.Load(this);
     }
-} 
+}

--- a/Wikalyzer/Wikalyzer/Views/OfflineSearchView.axaml
+++ b/Wikalyzer/Wikalyzer/Views/OfflineSearchView.axaml
@@ -4,52 +4,62 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:Wikalyzer.ViewModels"
              mc:Ignorable="d"
-             d:DesignWidth="800"
+             d:DesignWidth="1000"
              d:DesignHeight="600"
              x:Class="Wikalyzer.Views.OfflineSearchView"
              x:DataType="vm:OfflineSearchViewModel">
 
-  <!-- Ermöglicht Scrollen des gesamten Inhalts bei sehr langem Ergebnis -->
-  <ScrollViewer VerticalScrollBarVisibility="Auto"
-                Background="#F9F9F9"
-                Padding="20">
+  <Border Padding="20" Background="#1A2D3A">
+    <Grid ColumnDefinitions="3*,2*" RowDefinitions="Auto" ColumnSpacing="20">
 
-    <!-- Grid für feste Platzaufteilung -->
-    <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto"
-          RowSpacing="16">
 
-      <!-- Zeile 0: Überschrift -->
-      <TextBlock Grid.Row="0"
-                 Text="Wikipedia-Text eingeben:"
+    <!-- Linke Spalte: Text + Analyse -->
+    <StackPanel Grid.Column="0" Spacing="12">
+
+      <TextBlock Text="Wikipedia-Text eingeben:"
                  FontSize="18"
                  FontWeight="Bold"
-                 Foreground="#222222"/>
+                 Foreground="White"/>
 
-      <!-- Zeile 1: Eingabe-TextBox, Maximalhöhe 200px, intern scrollbar -->
-      <TextBox Grid.Row="1"
-               AcceptsReturn="True"
+      <TextBox AcceptsReturn="True"
                AcceptsTab="True"
+               TextWrapping="Wrap"
                Text="{Binding InputText, Mode=TwoWay}"
                Background="White"
                Foreground="#111111"
                Padding="8"
                BorderBrush="#CCCCCC"
-               MaxHeight="200"
-               ScrollViewer.VerticalScrollBarVisibility="Auto"
-               ScrollViewer.HorizontalScrollBarVisibility="Auto"/>
+               Height="300"
+               ScrollViewer.VerticalScrollBarVisibility="Auto"/>
 
-      <!-- Zeile 2: Analyse-Button -->
-      <Button Grid.Row="2"
-              Content="Analysieren"
-              Command="{Binding AnalyzeCommand}"
-              Background="#0066CC"
-              Foreground="White"
-              FontWeight="SemiBold"
-              Padding="12,8"
-              CornerRadius="4"/>
+      <Button Content="Analysieren"
+              Command="{Binding AnalyzeCommand}">
+        <Button.Styles>
+          <Style Selector="Button">
+            <Setter Property="Background" Value="#4FC3F7"/>
+            <Setter Property="Foreground" Value="Black"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Padding" Value="12,8"/>
+            <Setter Property="CornerRadius" Value="4"/>
+            <Setter Property="BorderBrush" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+          </Style>
 
-      <!-- Zeile 3: Ladeindikator -->
-      <StackPanel Grid.Row="3" Spacing="4">
+          <!-- Hover -->
+          <Style Selector="Button:pointerover">
+            <Setter Property="Background" Value="#03A9F4"/>
+          </Style>
+
+          <!-- Pressed -->
+          <Style Selector="Button:pressed">
+            <Setter Property="Background" Value="#039BE5"/>
+          </Style>
+        </Button.Styles>
+      </Button>
+
+
+
+      <StackPanel Spacing="4">
         <ProgressBar IsVisible="{Binding IsAnalyzing}"
                      IsIndeterminate="True"
                      Height="4"
@@ -61,82 +71,130 @@
                    HorizontalAlignment="Center"/>
       </StackPanel>
 
-      <!-- Zeile 4: Ergebnis-Panel -->
-    <Border Grid.Row="4"
-        Background="White"
-        CornerRadius="6"
-        Padding="16"
-        BorderBrush="#DDDDDD"
-        BorderThickness="1">
-  <StackPanel Spacing="8">
-    <TextBlock Text="Ergebnisse:"
-               FontSize="16"
-               FontWeight="SemiBold"
-               Foreground="#222222"/>
-
-    <!-- Wörter -->
-    <StackPanel Orientation="Horizontal" Spacing="4">
-      <TextBlock Text="{Binding Stats.WordCount, StringFormat=Wörter: {0}}"/>
-      <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
-        <ToolTip.Tip>
-          <ToolTip>
-            <TextBlock Text="Anzahl aller Wörter im eingegebenen Text"/>
-          </ToolTip>
-        </ToolTip.Tip>
-      </TextBlock>
     </StackPanel>
 
-    <!-- Sätze -->
-    <StackPanel Orientation="Horizontal" Spacing="4">
-      <TextBlock Text="{Binding Stats.SentenceCount, StringFormat=Sätze: {0}}"/>
-      <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
-        <ToolTip.Tip>
-          <ToolTip>
-            <TextBlock Text="Anzahl der Sätze, erkannt an ., ! oder ?"/>
-          </ToolTip>
-        </ToolTip.Tip>
-      </TextBlock>
-    </StackPanel>
+    <!-- Rechte Spalte: Ergebnisse -->
+    <Border Grid.Column="1"
+            Background="White"
+            CornerRadius="6"
+            Padding="16"
+            BorderBrush="Transparent"
+            BorderThickness="1"
+            MaxHeight="1000">
 
-    <!-- Ø Wortlänge -->
-    <StackPanel Orientation="Horizontal" Spacing="4">
-      <TextBlock Text="{Binding Stats.AvgWordLength, StringFormat=Ø Wortlänge: {0:F2}}"/>
-      <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
-        <ToolTip.Tip>
-          <ToolTip>
-            <TextBlock Text="Durchschnittliche Länge aller Wörter in Zeichen"/>
-          </ToolTip>
-        </ToolTip.Tip>
-      </TextBlock>
-    </StackPanel>
+      <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <StackPanel Spacing="8">
+          <TextBlock Text="Ergebnisse:"
+                     FontSize="16"
+                     FontWeight="SemiBold"
+                     Foreground="#222222"/>
 
-    <!-- Ø Satzlänge -->
-    <StackPanel Orientation="Horizontal" Spacing="4">
-      <TextBlock Text="{Binding Stats.AvgSentenceLength, StringFormat=Ø Satzlänge: {0:F2}}"/>
-      <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
-        <ToolTip.Tip>
-          <ToolTip>
-            <TextBlock Text="Durchschnittliche Wortanzahl pro Satz"/>
-          </ToolTip>
-        </ToolTip.Tip>
-      </TextBlock>
-    </StackPanel>
+          <!-- Wörter -->
+          <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="{Binding Stats.WordCount, StringFormat=Wörter: {0}}"/>
+            <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
+              <ToolTip.Tip>
+                <ToolTip>
+                  <TextBlock Text="Anzahl aller Wörter im eingegebenen Text"/>
+                </ToolTip>
+              </ToolTip.Tip>
+            </TextBlock>
+          </StackPanel>
 
-    <!-- Wortvielfalt -->
-    <StackPanel Orientation="Horizontal" Spacing="4">
-      <TextBlock Text="{Binding Stats.WordDiversity, StringFormat=Wortvielfalt: {0:P1}}"/>
-      <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
-        <ToolTip.Tip>
-          <ToolTip>
-            <TextBlock Text="Anteil eindeutiger Wörter am Gesamtwortvorrat"/>
-          </ToolTip>
-        </ToolTip.Tip>
-      </TextBlock>
-    </StackPanel>
+          <!-- Sätze -->
+          <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="{Binding Stats.SentenceCount, StringFormat=Sätze: {0}}"/>
+            <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
+              <ToolTip.Tip>
+                <ToolTip>
+                  <TextBlock Text="Anzahl der Sätze, erkannt an ., ! oder ?"/>
+                </ToolTip>
+              </ToolTip.Tip>
+            </TextBlock>
+          </StackPanel>
 
-  </StackPanel>
-</Border>
+          <!-- Ø Wortlänge -->
+          <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="{Binding Stats.AverageWordLength, StringFormat=Ø Wortlänge: {0:F2}}"/>
+            <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
+              <ToolTip.Tip>
+                <ToolTip>
+                  <TextBlock Text="Durchschnittliche Länge aller Wörter in Zeichen"/>
+                </ToolTip>
+              </ToolTip.Tip>
+            </TextBlock>
+          </StackPanel>
 
-    </Grid>
-  </ScrollViewer>
+          <!-- Ø Satzlänge -->
+          <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="{Binding Stats.AverageSentenceLength, StringFormat=Ø Satzlänge: {0:F2}}"/>
+            <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
+              <ToolTip.Tip>
+                <ToolTip>
+                  <TextBlock Text="Durchschnittliche Wortanzahl pro Satz"/>
+                </ToolTip>
+              </ToolTip.Tip>
+            </TextBlock>
+          </StackPanel>
+
+          <!-- Wortvielfalt -->
+          <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="{Binding Stats.LexicalDiversity, StringFormat=Wortvielfalt: {0:P1}}"/>
+            <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
+              <ToolTip.Tip>
+                <ToolTip>
+                  <TextBlock Text="Anteil eindeutiger Wörter am Gesamtwortvorrat"/>
+                </ToolTip>
+              </ToolTip.Tip>
+            </TextBlock>
+          </StackPanel>
+
+          <!-- Lesedauer -->
+          <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="{Binding Stats.ReadingTimeMinutes, StringFormat=Lesedauer: {0:F2} min}"/>
+            <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
+              <ToolTip.Tip>
+                <ToolTip>
+                  <TextBlock Text="Geschätzte Lesezeit bei 200 Wörtern pro Minute"/>
+                </ToolTip>
+              </ToolTip.Tip>
+            </TextBlock>
+          </StackPanel>
+
+          <!-- Flesch-Wert -->
+          <StackPanel Orientation="Horizontal" Spacing="4">
+            <TextBlock Text="{Binding Stats.FleschReadingEase, StringFormat=Flesch-Wert: {0:F1}}"/>
+            <TextBlock Text="ᐩ" FontSize="14" Foreground="#0078D7">
+              <ToolTip.Tip>
+                <ToolTip>
+                  <TextBlock Text="Lesbarkeitsindex: höher = leichter zu lesen (Deutsch: bis 100)"/>
+                </ToolTip>
+              </ToolTip.Tip>
+            </TextBlock>
+          </StackPanel>
+
+          <!-- Kürzester Satz -->
+          <TextBlock Text="Kürzester Satz:" FontWeight="Bold" Margin="0,10,0,0"/>
+          <TextBlock Text="{Binding Stats.ShortestSentence}" TextWrapping="Wrap" Foreground="#444"/>
+
+          <!-- Längster Satz -->
+          <TextBlock Text="Längster Satz:" FontWeight="Bold" Margin="0,10,0,0"/>
+          <TextBlock Text="{Binding Stats.LongestSentence}" TextWrapping="Wrap" Foreground="#444"/>
+
+          <!-- Top-Wörter -->
+          <TextBlock Text="Top-Wörter:" FontWeight="Bold" Margin="0,10,0,0"/>
+          <ItemsControl ItemsSource="{Binding Stats.TopWords}">
+            <ItemsControl.ItemTemplate>
+              <DataTemplate>
+                <TextBlock Text="{Binding}" Foreground="#333"/>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+
+        </StackPanel>
+      </ScrollViewer>
+
+    </Border>
+
+  </Grid></Border>
 </UserControl>

--- a/Wikalyzer/Wikalyzer/Views/OnlineSearchView.axaml
+++ b/Wikalyzer/Wikalyzer/Views/OnlineSearchView.axaml
@@ -53,7 +53,9 @@
       <ListBox ItemsSource="{Binding SearchResults}"
                Background="#263B50"
                BorderBrush="Transparent"
-               MaxHeight="400">
+               MaxHeight="400"
+               DoubleTapped="OnResultDoubleTapped">
+
         <ListBox.ItemTemplate>
           <DataTemplate DataType="models:ArticleSearchResult">
             <Border Background="#2E4050"

--- a/Wikalyzer/Wikalyzer/Views/OnlineSearchView.axaml
+++ b/Wikalyzer/Wikalyzer/Views/OnlineSearchView.axaml
@@ -3,38 +3,77 @@
              xmlns:vm="clr-namespace:Wikalyzer.ViewModels"
              xmlns:models="clr-namespace:Wikalyzer.Models"
              xmlns:converters="clr-namespace:Wikalyzer.Converters"
+             xmlns:ia="using:Avalonia.Input"
              x:Class="Wikalyzer.Views.OnlineSearchView"
              x:DataType="vm:OnlineSearchViewModel"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d">
+
   <Border Background="#1A2D3A" Padding="20">
-    <StackPanel Spacing="10">
-      <TextBlock Text="Online-Suche"
+    <Grid RowDefinitions="Auto,Auto,*" RowSpacing="10">
+
+      <!-- Überschrift -->
+      <TextBlock Grid.Row="0"
+                 Text="Online-Suche"
                  FontSize="24" FontWeight="Bold"
                  Foreground="White"
                  HorizontalAlignment="Center"/>
 
-      <StackPanel Orientation="Horizontal" Spacing="8">
-        <ComboBox ItemsSource="{Binding Filters}"
+      <!-- Suchzeile -->
+      <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8">
+        <ComboBox Width="140"
+                  ItemsSource="{Binding Filters}"
                   SelectedItem="{Binding SelectedFilter}"
-                  Width="120"
                   Background="#263B50"
                   Foreground="White"
-                  BorderBrush="#4FC3F7">
+                  BorderBrush="#4FC3F7"
+                  HorizontalContentAlignment="Center"
+                  VerticalContentAlignment="Center">
+
+          <ComboBox.Resources>
+            <SolidColorBrush x:Key="ThemeBackgroundBrush" Color="#263B50"/>
+            <SolidColorBrush x:Key="ComboBoxPopupBackground" Color="#263B50"/>
+            <SolidColorBrush x:Key="ComboBoxBackground" Color="#263B50"/>
+            <SolidColorBrush x:Key="ComboBoxItemBackground" Color="#263B50"/>
+            <SolidColorBrush x:Key="ComboBoxItemPointerOverBackground" Color="#2F4A60"/>
+            <SolidColorBrush x:Key="ComboBoxItemSelectedBackground" Color="#4FC3F7"/>
+            <SolidColorBrush x:Key="ComboBoxItemSelectedForeground" Color="Black"/>
+            <SolidColorBrush x:Key="ComboBoxItemPointerOverForeground" Color="White"/>
+          </ComboBox.Resources>
+
           <ComboBox.ItemTemplate>
-            <DataTemplate DataType="models:NamespaceFilter">
-              <TextBlock Text="{Binding Name}" Foreground="White"/>
+            <DataTemplate>
+              <TextBlock Text="{Binding Name}"
+                         ToolTip.Tip="{Binding Description}"
+                         Padding="6,4"
+                         Background="Transparent"
+                         Foreground="White"/>
             </DataTemplate>
           </ComboBox.ItemTemplate>
         </ComboBox>
 
         <TextBox Width="250"
-                 Watermark="Begriff eingeben…"
                  Text="{Binding SearchTerm, Mode=TwoWay}"
-                 Background="#263B50"
-                 Foreground="White"
-                 BorderBrush="#4FC3F7"/>
+                 Watermark="Begriff eingeben…">
+          <TextBox.Styles>
+            <Style Selector="TextBox">
+              <Setter Property="Background" Value="#1E2D3A"/>
+              <Setter Property="Foreground" Value="White"/>
+              <Setter Property="CaretBrush" Value="White"/>
+              <Setter Property="BorderBrush" Value="#4FC3F7"/>
+              <Setter Property="FontSize" Value="14"/>
+              <Setter Property="Padding" Value="8,4"/>
+              <Style.Resources>
+                <SolidColorBrush x:Key="TextBoxWatermarkForeground" Color="#8899AA"/>
+              </Style.Resources>
+            </Style>
+          </TextBox.Styles>
+              <TextBox.KeyBindings>
+              <ia:KeyBinding Gesture="Enter"
+                             Command="{Binding SearchCommand}" />
+            </TextBox.KeyBindings>
+        </TextBox>
 
         <Button Content="Suchen"
                 Command="{Binding SearchCommand}"
@@ -50,42 +89,43 @@
                      Foreground="#4FC3F7"/>
       </StackPanel>
 
-      <ListBox ItemsSource="{Binding SearchResults}"
-               Background="#263B50"
-               BorderBrush="Transparent"
-               MaxHeight="400"
-               DoubleTapped="OnResultDoubleTapped">
-
-        <ListBox.ItemTemplate>
-          <DataTemplate DataType="models:ArticleSearchResult">
-            <Border Background="#2E4050"
-                    CornerRadius="4"
-                    Padding="8"
-                    Margin="0,4,0,0">
-              <StackPanel Orientation="Horizontal" Spacing="10">
-                <Image Width="80" Height="80"
-                       Stretch="UniformToFill"
-                       Source="{Binding ThumbnailUrl,
-                        Converter={StaticResource UrlToBitmapConverter}}"
-                       IsVisible="{Binding ThumbnailUrl,
-                          Converter={StaticResource NullToBooleanConverter}}"/>
-
-                <StackPanel>
-                  <TextBlock Text="{Binding Title}"
-                             FontWeight="SemiBold"
-                             Foreground="White"
-                             FontSize="14"/>
-                  <TextBlock Text="{Binding Summary}"
-                             TextWrapping="Wrap"
-                             Foreground="#DDDDDD"
-                             FontSize="12"
-                             MaxWidth="600"/>
+      <!-- Ergebnisliste -->
+      <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+        <ListBox ItemsSource="{Binding SearchResults}"
+                 Background="#263B50"
+                 BorderBrush="Transparent"
+                 DoubleTapped="OnResultDoubleTapped">
+          <ListBox.ItemTemplate>
+            <DataTemplate DataType="models:ArticleSearchResult">
+              <Border Background="#2E4050"
+                      CornerRadius="4"
+                      Padding="8"
+                      Margin="0,4,0,0">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                  <Image Width="80" Height="80"
+                         Stretch="UniformToFill"
+                         Source="{Binding ThumbnailUrl,
+                            Converter={StaticResource UrlToBitmapConverter}}"
+                         IsVisible="{Binding ThumbnailUrl,
+                            Converter={StaticResource NullToBooleanConverter}}"/>
+                  <StackPanel>
+                    <TextBlock Text="{Binding Title}"
+                               FontWeight="SemiBold"
+                               Foreground="White"
+                               FontSize="14"/>
+                    <TextBlock Text="{Binding Summary}"
+                               TextWrapping="Wrap"
+                               Foreground="#DDDDDD"
+                               FontSize="12"
+                               MaxWidth="600"/>
+                  </StackPanel>
                 </StackPanel>
-              </StackPanel>
-            </Border>
-          </DataTemplate>
-        </ListBox.ItemTemplate>
-      </ListBox>
-    </StackPanel>
+              </Border>
+            </DataTemplate>
+          </ListBox.ItemTemplate>
+        </ListBox>
+      </ScrollViewer>
+
+    </Grid>
   </Border>
 </UserControl>

--- a/Wikalyzer/Wikalyzer/Views/OnlineSearchView.axaml.cs
+++ b/Wikalyzer/Wikalyzer/Views/OnlineSearchView.axaml.cs
@@ -1,8 +1,8 @@
-// Views/OnlineSearchView.axaml.cs
+// Views/OnlineSearchView.xaml.cs
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Wikalyzer.Models;
-using System;
+using Wikalyzer.ViewModels;
 
 namespace Wikalyzer.Views;
 
@@ -13,13 +13,25 @@ public partial class OnlineSearchView : UserControl
         InitializeComponent();
     }
 
-    private void OnResultDoubleTapped(object? sender, RoutedEventArgs e)
+    private async void OnResultDoubleTapped(object? sender, RoutedEventArgs e)
     {
-        if (sender is ListBox lb && lb.SelectedItem is ArticleSearchResult article)
-        {
-            var url = $"https://de.wikipedia.org/wiki/{Uri.EscapeDataString(article.Title)}";
-            var window = new ArticleViewWindow(article.Title, url, article.Summary);
-            window.Show();
-        }
+        if (DataContext is not OnlineSearchViewModel vm)
+            return;
+
+        // Wenn wir im Datei/Bild-Modus sind, abbrechen (nicht öffnen)
+        if (vm.SelectedFilter.Id == 6)
+            return;
+
+        // Sonst normalen Artikel öffnen
+        if ((sender as ListBox)?.SelectedItem is not ArticleSearchResult item)
+            return;
+
+        var owner = this.VisualRoot as Window;
+
+        var artVm = new ArticleViewModel(item.Title,
+            item.PageUrl,
+            item.Summary);
+        var artWin = new ArticleViewWindow { DataContext = artVm };
+        await artWin.ShowDialog(owner!);
     }
 }

--- a/Wikalyzer/Wikalyzer/Views/OnlineSearchView.axaml.cs
+++ b/Wikalyzer/Wikalyzer/Views/OnlineSearchView.axaml.cs
@@ -1,5 +1,8 @@
+// Views/OnlineSearchView.axaml.cs
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
+using Avalonia.Interactivity;
+using Wikalyzer.Models;
+using System;
 
 namespace Wikalyzer.Views;
 
@@ -10,8 +13,13 @@ public partial class OnlineSearchView : UserControl
         InitializeComponent();
     }
 
-    private void InitializeComponent()
+    private void OnResultDoubleTapped(object? sender, RoutedEventArgs e)
     {
-        AvaloniaXamlLoader.Load(this);
+        if (sender is ListBox lb && lb.SelectedItem is ArticleSearchResult article)
+        {
+            var url = $"https://de.wikipedia.org/wiki/{Uri.EscapeDataString(article.Title)}";
+            var window = new ArticleViewWindow(article.Title, url, article.Summary);
+            window.Show();
+        }
     }
 }

--- a/Wikalyzer/Wikalyzer/Wikalyzer.csproj
+++ b/Wikalyzer/Wikalyzer/Wikalyzer.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+    
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
@@ -6,6 +7,7 @@
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+        <UseWebView2>true</UseWebView2>
     </PropertyGroup>
 
     <ItemGroup>
@@ -22,7 +24,7 @@
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+            <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="System.Text.Json" Version="9.0.7" />
         </ItemGroup>
 

--- a/Wikalyzer/Wikalyzer/Wikalyzer.csproj
+++ b/Wikalyzer/Wikalyzer/Wikalyzer.csproj
@@ -25,6 +25,8 @@
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
             <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+            <PackageReference Include="HtmlAgilityPack" Version="1.12.2" />
+            <PackageReference Include="Markdig" Version="0.41.3" />
         <PackageReference Include="System.Text.Json" Version="9.0.7" />
         </ItemGroup>
 


### PR DESCRIPTION
# Pull Request: “Artikel-Ansicht” mit formatiertem Text & Analyse-Sidebar

## Überblick
Dieser PR fügt eine komplett neue **Artikel-Ansicht** hinzu, in der:
- der Wikipedia‑Artikel per REST‑API geholt wird,
- das HTML per Regex in übersichtlichen Plain‑Text umgewandelt wird,
- der formatierte Text in der App angezeigt wird,
- eine Sidebar per `Border`/`StackPanel` Lade‑ und Analyse‑Buttons bereithält.

 **WebView2** wurde entfernt, um unter .NET 8 ohne inkompatible Pakete auszukommen.

---

## Neue Dateien & Hauptänderungen

### Services/WikiRestClient.cs
- `GetArticleHtmlAsync(string title)`  
  → ruft `api/rest_v1/page/html/{title}` ab.
- `GetArticlePlainTextAsync(string title)`  
  → Regex‑Parser für `<h1>, <h2>, <p>` → Großbuchstaben‑Überschriften + Absätze.

### ViewModels/ArticleViewModel.cs
- Properties:
  - `string Title`, `string ArticleUrl`, `string Summary`
  - `[ObservableProperty] string ArticleText`
  - `[ObservableProperty] TextStats Stats`
  - `[ObservableProperty] bool IsSidebarOpen`
- Commands:
  - `[RelayCommand] LoadArticleTextAsync()` → füllt `ArticleText`
  - `[RelayCommand] Analyze()` → wertet `ArticleText` mit `TextAnalyzer` aus

### Views/ArticleViewWindow.axaml
- **Grid** mit 2 Spalten:
  - Links: `<Border><ScrollViewer><TextBlock Text="{Binding ArticleText}"/></ScrollViewer></Border>`
  - Rechts: `<Border><DockPanel><StackPanel>` mit
    - Button **„Artikel laden“** → `LoadArticleTextCommand`
    - Statistik‑Labels (`Stats.WordCount`, `Stats.SentenceCount`)
    - Button **„Analyse starten“** → `AnalyzeCommand`

### Views/ArticleViewWindow.axaml.cs
- Konstruktor übernimmt `(string title, string url, string summary)`  
- Setzt `DataContext = new ArticleViewModel(...)`

---

## Test
1. **App starten** und über Doppelklick aus der Online‑Suche einen Artikel öffnen.  
2. Im neuen Fenster auf **„Artikel laden“** klicken → der formatierte Text soll erscheinen.  
3. Auf **„Analyse starten“** klicken → die Statistik‑Werte (`Wörter`, `Sätze`) werden aktualisiert.  
4. UI-Abstände prüfen: Abstand um Textbereich und Sidebar korrekt per `Border` eingerückt.
