### PR TITLE
Dashboard UI & HomePageViewModel erstellt

### DIFF
--- a/Wikalyzer/Wikalyzer/ViewModels/HomePageViewModel.cs
+++ b/Wikalyzer/Wikalyzer/ViewModels/HomePageViewModel.cs
@@ -1,6 +1,51 @@
+// ViewModels/HomePageViewModel.cs
+using System;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
 namespace Wikalyzer.ViewModels;
 
-public class HomePageViewModel : ViewModelBase
+public partial class HomePageViewModel : ViewModelBase
 {
-    
+    // ─── Kennzahlen (KPIs) ───
+    [ObservableProperty]
+    private int _totalOfflineAnalyses;
+
+    [ObservableProperty]
+    private int _totalOnlineSearches;
+
+    [ObservableProperty]
+    private DateTime _lastAnalysisDate;
+
+    // ─── Liste der letzten Analysen ───
+    [ObservableProperty]
+    private ObservableCollection<string> _recentAnalyses = new();
+
+    public HomePageViewModel()
+    {
+        // Beispiel‑Initialisierung
+        TotalOfflineAnalyses  = 5;
+        TotalOnlineSearches   = 3;
+        LastAnalysisDate      = DateTime.Now.AddDays(-1);
+        RecentAnalyses        = new ObservableCollection<string>
+        {
+            "Einstein-Analyse",
+            "UI-Layout-Test",
+            "Regex-Parser-Demo"
+        };
+    }
+
+    // ─── Schnellzugriffe / Navigation ───
+    [RelayCommand]
+    private void NavigateOfflineSearch()
+    {
+        // TODO: über MainWindowViewModel.SelectedListItem navigieren
+    }
+
+    [RelayCommand]
+    private void NavigateOnlineSearch()
+    {
+        // TODO: über MainWindowViewModel.SelectedListItem navigieren
+    }
 }

--- a/Wikalyzer/Wikalyzer/Views/HomePageView.axaml
+++ b/Wikalyzer/Wikalyzer/Views/HomePageView.axaml
@@ -1,8 +1,68 @@
-<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             x:Class="Wikalyzer.Views.HomePageView">
-    Welcome to Avalonia!
+<!-- Views/HomePageView.axaml -->
+<UserControl
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:vm="clr-namespace:Wikalyzer.ViewModels"
+    x:Class="Wikalyzer.Views.HomePageView"
+    x:DataType="vm:HomePageViewModel">
+
+  <!-- Außenabstand -->
+  <Border Padding="20">
+    <StackPanel Spacing="20">
+
+      <!-- Titel -->
+      <TextBlock Text="Dashboard"
+                 FontSize="24"
+                 FontWeight="Bold"/>
+
+      <!-- KPI-Cards -->
+      <Grid ColumnDefinitions="*,*,*">
+        <!-- Offline-Analysen -->
+        <Border Background="#4FC3F7" CornerRadius="8" Padding="10" Margin="5">
+          <StackPanel>
+            <TextBlock Text="Offline-Analysen" FontWeight="SemiBold" Foreground="White"/>
+            <TextBlock Text="{Binding TotalOfflineAnalyses}" FontSize="20" Foreground="White"/>
+          </StackPanel>
+        </Border>
+        <!-- Online-Suchen -->
+        <Border Grid.Column="1" Background="#FFB300" CornerRadius="8" Padding="10" Margin="5">
+          <StackPanel>
+            <TextBlock Text="Online-Suchen" FontWeight="SemiBold" Foreground="White"/>
+            <TextBlock Text="{Binding TotalOnlineSearches}" FontSize="20" Foreground="White"/>
+          </StackPanel>
+        </Border>
+        <!-- Letzte Analyse -->
+        <Border Grid.Column="2" Background="#66BB6A" CornerRadius="8" Padding="10" Margin="5">
+          <StackPanel>
+            <TextBlock Text="Letzte Analyse" FontWeight="SemiBold" Foreground="White"/>
+            <TextBlock Text="{Binding LastAnalysisDate, StringFormat={}{0:dd.MM.yyyy HH:mm}}"
+                       FontSize="16" Foreground="White"/>
+          </StackPanel>
+        </Border>
+      </Grid>
+
+      <!-- Letzte Analysen -->
+      <StackPanel>
+        <TextBlock Text="Letzte Analysen" FontSize="18" FontWeight="SemiBold"/>
+        <ListBox ItemsSource="{Binding RecentAnalyses}"
+                 MaxHeight="150"
+                 Margin="0,5,0,0"/>
+      </StackPanel>
+
+      <!-- Schnellzugriffe -->
+      <StackPanel Orientation="Horizontal" Spacing="10">
+        <Button Content="Offline-Suche starten"
+                Command="{Binding NavigateOfflineSearchCommand}"
+                Background="#4FC3F7"
+                Foreground="Black"
+                Padding="10,5"/>
+        <Button Content="Online-Suche starten"
+                Command="{Binding NavigateOnlineSearchCommand}"
+                Background="#FFB300"
+                Foreground="Black"
+                Padding="10,5"/>
+      </StackPanel>
+
+    </StackPanel>
+  </Border>
 </UserControl>

--- a/Wikalyzer/Wikalyzer/Views/HomePageView.axaml.cs
+++ b/Wikalyzer/Wikalyzer/Views/HomePageView.axaml.cs
@@ -1,4 +1,4 @@
-using Avalonia;
+// Views/HomePageView.axaml.cs
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
@@ -10,4 +10,6 @@ public partial class HomePageView : UserControl
     {
         InitializeComponent();
     }
+
+    private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 }


### PR DESCRIPTION
# Pull Request: Dashboard-UI & HomePageViewModel

## Überblick
Dieser PR fügt das **Dashboard** als Startseite („Home“) hinzu. Nutzer:innen sehen auf einen Blick:
- zentrale Kennzahlen (Offline‑Analysen, Online‑Suchen, Datum der letzten Analyse)
- Liste der zuletzt durchgeführten Analysen
- Schnellzugriff-Buttons zur Offline‑ bzw. Online‑Suche

---

## Änderungen

### 1. ViewModel: `HomePageViewModel.cs`
- Properties (KPIs):
  - `TotalOfflineAnalyses` (int)
  - `TotalOnlineSearches` (int)
  - `LastAnalysisDate` (DateTime)
- Collection:
  - `RecentAnalyses` (ObservableCollection<string>) mit Dummy‑Einträgen
- Commands:
  - `NavigateOfflineSearchCommand`
  - `NavigateOnlineSearchCommand`

### 2. View: `HomePageView.axaml`
- `UserControl` mit `x:DataType="vm:HomePageViewModel"`
- `Border` für Außenabstand
- `Grid` mit drei KPI‑Cards:
  - Offline‑Analysen (hellblau)
  - Online‑Suchen (orange)
  - Letzte Analyse (grün)
- Abschnitt „Letzte Analysen“ als `ListBox`
- Schnellzugriff-Buttons im `StackPanel`

### 3. Code‑Behind: `HomePageView.axaml.cs`
- Standard‑Initialisierung via `AvaloniaXamlLoader.Load(this)`

---

## Tests
1. App starten → Dashboard erscheint als erste Ansicht.  
2. KPI‑Werte werden korrekt aus dem ViewModel angezeigt (Dummy‑Werte).  
3. „Letzte Analysen“ listet die Einträge aus `RecentAnalyses`.    
4. Layout skaliert bei Fenstergrößenänderung sauber, Abstände sind korrekt.